### PR TITLE
Career Management & Bug Fixes

### DIFF
--- a/CCL_GameScripts/Editor/ExportTrainCar.cs
+++ b/CCL_GameScripts/Editor/ExportTrainCar.cs
@@ -108,6 +108,7 @@ public class ExportTrainCar : EditorWindow
 					
 					//Close the window when we are done building.
 					Close();
+					return;
 				}
 			}
 		}
@@ -148,6 +149,7 @@ public class ExportTrainCar : EditorWindow
 		if (GUILayout.Button("Close"))
 		{
 			Close();
+			return;
 		}
 
 		GUILayout.EndVertical(); // -1

--- a/CCL_GameScripts/Editor/TrainCarValidator.cs
+++ b/CCL_GameScripts/Editor/TrainCarValidator.cs
@@ -21,7 +21,7 @@ namespace CCL_GameScripts
 
         private enum ResultStatus
         {
-            Pass, Warning, Failed
+            Pass, Warning, Failed, Skipped
         }
 
         private class Result
@@ -40,6 +40,7 @@ namespace CCL_GameScripts
             public static Result Pass() => new Result(null, ResultStatus.Pass);
             public static Result Warning(string message) => new Result(null, ResultStatus.Warning, message);
             public static Result Failed(string message) => new Result(null, ResultStatus.Failed, message);
+            public static Result Skipped() => new Result(null, ResultStatus.Skipped);
 
             public Color StatusColor
             {
@@ -162,6 +163,7 @@ namespace CCL_GameScripts
             Run(CheckColliders);
             Run(CheckCouplers);
             Run(CheckCabTransform);
+            Run(CheckCargoSettings);
         }
 
         private void Run(Func<Result> test)
@@ -421,6 +423,29 @@ namespace CCL_GameScripts
                 {
                     return Result.Warning("Interior is not centered at (0,0,0)");
                 }
+            }
+
+            return Result.Pass();
+        }
+
+        [CarPrefabTest("Cargo Settings")]
+        private Result CheckCargoSettings()
+        {
+            bool isCustomCargoClass = trainCarSetup.CargoClass == BaseCargoContainerType.Custom;
+            var cargoModels = trainCarSetup.GetComponents<CargoModelSetup>();
+
+            if (!isCustomCargoClass && cargoModels.Length == 0)
+            {
+                return Result.Skipped();
+            }
+
+            if (!isCustomCargoClass) // models length > 0
+            {
+                return Result.Warning($"Cargo models are set up, but car is set to use base container type {trainCarSetup.CargoClass}");
+            }
+            if (cargoModels.Length == 0) // is custom cargo class
+            {
+                return Result.Warning("Car is set to custom cargo container, but no cargo models are set up - will not be able to carry cargo");
             }
 
             return Result.Pass();

--- a/CCL_GameScripts/SimParamsSteam.cs
+++ b/CCL_GameScripts/SimParamsSteam.cs
@@ -32,7 +32,6 @@ namespace CCL_GameScripts
 
         [Header("Fuel")]
         public SteamFuelType FuelType;
-        public string TenderIdentifier;
         public bool IsTankLoco = false;
         public float BunkerWaterCapacity = 0;
         public float BunkerFuelCapacity = 0;

--- a/CCL_GameScripts/TrainCarSetup.cs
+++ b/CCL_GameScripts/TrainCarSetup.cs
@@ -49,6 +49,11 @@ namespace CCL_GameScripts
         [ProxyField]
         public bool keepInteriorLoaded = false;
 
+        [Header("Auto Spawning (Locos Only)")]
+        [InspectorName("Spawn Locations")]
+        public StationYard LocoSpawnLocations = StationYard.None;
+        public string TenderID;
+
         [Header("Cargo & Jobs")]
         public BaseCargoContainerType CargoClass = BaseCargoContainerType.None;
         public bool ReplaceBaseType = false;

--- a/DVCustomCarLoader/CCLSettings.cs
+++ b/DVCustomCarLoader/CCLSettings.cs
@@ -3,26 +3,57 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 using UnityModManagerNet;
 
 namespace DVCustomCarLoader
 {
-    public class CCLSettings : UnityModManager.ModSettings, IDrawable
+    public class CCLSettings : UnityModManager.ModSettings
     {
-        [Draw("Prefer custom cars to default cars when generating jobs")]
         public bool PreferCustomCarsForJobs = false;
-
-        [Draw("Verbose Logging")]
         public bool VerboseMode = true;
 
-        public void OnChange()
+        public SpawnerFeeBehavior LocoFeeBehavior = SpawnerFeeBehavior.DefaultNoTracking;
+
+        public bool FeesForCCLLocos => 
+            LocoFeeBehavior == SpawnerFeeBehavior.TrackCCLLocos ||
+            LocoFeeBehavior == SpawnerFeeBehavior.TrackAllLocos;
+
+        public bool FeesForAllLocos =>
+            LocoFeeBehavior == SpawnerFeeBehavior.TrackAllLocos;
+
+        public void Draw(UnityModManager.ModEntry modEntry)
         {
-            
+            GUILayout.BeginVertical();
+
+            PreferCustomCarsForJobs = GUILayout.Toggle(PreferCustomCarsForJobs, "Prefer custom cars to default cars when generating jobs");
+            VerboseMode = GUILayout.Toggle(VerboseMode, "Verbose Logging");
+            GUILayout.Space(2);
+
+            GUILayout.Label("Career Manager fee behavior for player-spawned locos:");
+            LocoFeeBehavior = (SpawnerFeeBehavior)GUILayout.SelectionGrid((int)LocoFeeBehavior, spawnerBehaviorDescriptions, 1, "toggle");
+            GUILayout.Space(2);
+
+            GUILayout.EndVertical();
         }
 
         public override void Save(UnityModManager.ModEntry modEntry)
         {
             Save(this, modEntry);
         }
+
+        public enum SpawnerFeeBehavior
+        {
+            DefaultNoTracking,
+            TrackCCLLocos,
+            TrackAllLocos
+        }
+
+        private static readonly string[] spawnerBehaviorDescriptions = new[]
+        {
+            "Don't track spawned locos (default)",
+            "Track player-spawned CCL locos",
+            "Track all player-spawned locos"
+        };
     }
 }

--- a/DVCustomCarLoader/CargoModelInjector.cs
+++ b/DVCustomCarLoader/CargoModelInjector.cs
@@ -109,7 +109,11 @@ namespace DVCustomCarLoader
                         nameList = new List<string>();
                         modelDict.Add(cargoType, nameList);
                     }
-                    nameList.Add(modelName);
+
+                    if (!string.IsNullOrEmpty(modelName))
+                    {
+                        nameList.Add(modelName);
+                    }
                 }
             }
         }

--- a/DVCustomCarLoader/CustomCar.cs
+++ b/DVCustomCarLoader/CustomCar.cs
@@ -34,6 +34,9 @@ namespace DVCustomCarLoader
 
         public GameObject InteriorPrefab;
 
+        public StationYard LocoSpawnLocations { get; protected set; }
+        public string TenderID { get; protected set; }
+
         //Bogies
         public CustomBogieParams FrontBogieConfig = null;
         public CustomBogieParams RearBogieConfig = null;
@@ -303,6 +306,9 @@ namespace DVCustomCarLoader
             BookletSprite = carSetup.BookletSprite;
             FullDamagePrice = carSetup.FullDamagePrice;
             ReplaceBaseType = carSetup.ReplaceBaseType;
+
+            LocoSpawnLocations = carSetup.LocoSpawnLocations;
+            TenderID = carSetup.TenderID;
 
             CargoClass = (CargoContainerType)carSetup.CargoClass;
 

--- a/DVCustomCarLoader/CustomCar.cs
+++ b/DVCustomCarLoader/CustomCar.cs
@@ -514,6 +514,20 @@ namespace DVCustomCarLoader
             bufferRoot = Object.Instantiate(bufferRoot, newPrefab.transform);
             bufferRoot.name = CarPartNames.BUFFERS_ROOT;
 
+            // special case for refrigerator - chain rigs are parented to car root instead of [buffers]
+            if (BaseCarType == TrainCarType.RefrigeratorWhite)
+            {
+                for (int i = 0; i < basePrefab.transform.childCount; i++)
+                {
+                    var child = basePrefab.transform.GetChild(i).gameObject;
+                    if (child.name == CarPartNames.BUFFER_CHAIN_REGULAR)
+                    {
+                        GameObject copiedChain = Object.Instantiate(child, bufferRoot.transform);
+                        copiedChain.name = CarPartNames.BUFFER_CHAIN_REGULAR;
+                    }
+                }
+            }
+
             // adjust transforms of buffer components
             for (int i = 0; i < bufferRoot.transform.childCount; i++)
             {

--- a/DVCustomCarLoader/CustomCargoInjector.cs
+++ b/DVCustomCarLoader/CustomCargoInjector.cs
@@ -229,15 +229,6 @@ namespace DVCustomCarLoader
                 }
             }
         }
-
-        [HarmonyPatch(typeof(LogicController), "Start")]
-        [HarmonyPostfix]
-        public static void LogicController_Start_Postfix(ref IEnumerator __result)
-        {
-            var wrapped = new WrappedEnumerator(__result);
-            wrapped.OnComplete += CustomCargoInjector.OnLogicControllerInitialized;
-            __result = wrapped;
-        }
     }
 
     [HarmonyPatch(typeof(CommsRadioCargoLoader))]

--- a/DVCustomCarLoader/DVCustomCarLoader.csproj
+++ b/DVCustomCarLoader/DVCustomCarLoader.csproj
@@ -121,6 +121,7 @@
     <Compile Include="LocoComponents\Steam\CustomTenderSimulation.cs" />
     <Compile Include="LocoComponents\Steam\ShovelPatches.cs" />
     <Compile Include="LocoComponents\VisitCheckerPatch.cs" />
+    <Compile Include="LocoSpawnerInjector.cs" />
     <Compile Include="ModPatches.cs" />
     <Compile Include="CustomCar.cs" />
     <Compile Include="CustomCarManager.cs" />

--- a/DVCustomCarLoader/Effects/DrivingAnimation.cs
+++ b/DVCustomCarLoader/Effects/DrivingAnimation.cs
@@ -35,6 +35,8 @@ namespace DVCustomCarLoader.Effects
 		protected LocoControllerBase loco;
 		protected float curVelocity;
 
+		public float defaultRotationSpeed;
+
 		protected static Vector3 WorldToLocalAxis(RotationAxis axis)
         {
 			if (axis == RotationAxis.XAxis) return Vector3.right;
@@ -130,6 +132,9 @@ namespace DVCustomCarLoader.Effects
             {
 				curVelocity = 0;
             }
+
+			defaultRotationSpeed = curVelocity / DefaultWheelRadius;
+			defaultRotationSpeed = Mathf.Lerp(defaultRotationSpeed, Mathf.Sign(loco.reverser) * MaxWheelslipMultiplier, loco.drivingForce.wheelslip);
 
 			SetRevSpeeds(transformCircumferences, transformRevSpeed);
 			UpdateTransformRotations();

--- a/DVCustomCarLoader/Extensions.cs
+++ b/DVCustomCarLoader/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using CCL_GameScripts;
 using DV.Logic.Job;
+using HarmonyLib;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -155,6 +156,25 @@ namespace DVCustomCarLoader
         public void Reset()
         {
             enumerator.Reset();
+        }
+    }
+
+    [HarmonyPatch(typeof(Enum), nameof(Enum.IsDefined))]
+    public static class EnumPatch
+    {
+        public static bool Prefix(Type enumType, object value, ref bool __result)
+        {
+            if ((enumType == typeof(TrainCarType)) && (value is TrainCarType carType))
+            {
+                __result = CarTypeInjector.IsCustomTypeRegistered(carType);
+                if (__result) return false;
+            }
+            else if ((enumType == typeof(CargoType)) && (value is CargoType cargoType))
+            {
+                __result = CustomCargoInjector.IsCustomTypeRegistered(cargoType);
+                if (__result) return false;
+            }
+            return true;
         }
     }
 }

--- a/DVCustomCarLoader/InitSpecManager.cs
+++ b/DVCustomCarLoader/InitSpecManager.cs
@@ -25,7 +25,7 @@ namespace DVCustomCarLoader
                 {
                     if (m.GetCustomAttribute<InitSpecAfterInitAttribute>() is InitSpecAfterInitAttribute attribute)
                     {
-                        Main.LogVerbose($"Static After Init Found: {t.Name}.{m.Name}, spec = {attribute.SpecType.Name}");
+                        //Main.LogVerbose($"Static After Init Found: {t.Name}.{m.Name}, spec = {attribute.SpecType.Name}");
 
                         var parameters = m.GetParameters();
                         if ((parameters.Length == 2) && 
@@ -42,7 +42,7 @@ namespace DVCustomCarLoader
                     }
                     else if (m.GetCustomAttribute<CopySpecAfterInitAttribute>() is CopySpecAfterInitAttribute copyAfterInit)
                     {
-                        Main.LogVerbose($"Static After Copy Found: {t.Name}.{m.Name}, spec = {copyAfterInit.SpecType.Name}");
+                        //Main.LogVerbose($"Static After Copy Found: {t.Name}.{m.Name}, spec = {copyAfterInit.SpecType.Name}");
 
                         var parameters = m.GetParameters();
                         if ((parameters.Length == 2) &&
@@ -67,7 +67,7 @@ namespace DVCustomCarLoader
             {
                 if (sf.Key.IsAssignableFrom(spec.GetType()))
                 {
-                    Main.LogVerbose($"StaticAfterInit {sf.Key.Name} ({spec.GetType().Name}) - {realComp.name}");
+                    //Main.LogVerbose($"StaticAfterInit {sf.Key.Name} ({spec.GetType().Name}) - {realComp.name}");
 
                     sf.Value.Invoke(null, new object[] { spec, realComp });
                 }
@@ -80,7 +80,7 @@ namespace DVCustomCarLoader
             {
                 if (sf.Key.IsAssignableFrom(spec.GetType()))
                 {
-                    Main.LogVerbose($"StaticAfterCopy {sf.Key.Name} ({spec.GetType().Name}) - {newObject.name}");
+                    //Main.LogVerbose($"StaticAfterCopy {sf.Key.Name} ({spec.GetType().Name}) - {newObject.name}");
 
                     sf.Value.Invoke(null, new object[] { spec, newObject });
                 }

--- a/DVCustomCarLoader/LocoComponents/CustomLocoController.cs
+++ b/DVCustomCarLoader/LocoComponents/CustomLocoController.cs
@@ -211,7 +211,7 @@ namespace DVCustomCarLoader.LocoComponents
         {
             train.LogicCarInitialized -= OnLogicCarInitialized;
 
-            if( !train.playerSpawnedCar )
+            if (!train.playerSpawnedCar || Main.Settings.FeesForCCLLocos)
             {
                 locoDebt = new DebtTrackerCustomLoco(train.ID, train.carType, this, damageController, sim);
                 SingletonBehaviour<LocoDebtController>.Instance.RegisterLocoDebtTracker(locoDebt);
@@ -224,7 +224,7 @@ namespace DVCustomCarLoader.LocoComponents
         protected virtual void OnLocoDestroyed( TrainCar train )
         {
             train.OnDestroyCar -= OnLocoDestroyed;
-            if( !train.playerSpawnedCar )
+            if ((!train.playerSpawnedCar || Main.Settings.FeesForCCLLocos) && (locoDebt != null))
             {
                 SingletonBehaviour<LocoDebtController>.Instance.StageLocoDebtOnLocoDestroy(locoDebt);
             }

--- a/DVCustomCarLoader/LocoComponents/Steam/CustomChuffController.cs
+++ b/DVCustomCarLoader/LocoComponents/Steam/CustomChuffController.cs
@@ -46,7 +46,7 @@ namespace DVCustomCarLoader.LocoComponents.Steam
         protected void Update()
         {
             chuffPower = loco.GetTotalPowerForcePercentage();
-            float speed = (loco.drivingForce.wheelslip > 0f) ? (driverAnimation.DefaultWheelRadius * wheelCircumference) : loco.GetForwardSpeed();
+            float speed = Mathf.Abs((loco.drivingForce.wheelslip > 0f) ? (driverAnimation.defaultRotationSpeed * wheelCircumference) : loco.GetForwardSpeed());
 
             revolutionPos = (revolutionPos + speed * Time.deltaTime) % wheelCircumference;
             currentChuff = (int)(revolutionPos / wheelCircumference * chuffsPerRevolution) % chuffsPerRevolution;

--- a/DVCustomCarLoader/LocoComponents/Steam/CustomTenderSimulation.cs
+++ b/DVCustomCarLoader/LocoComponents/Steam/CustomTenderSimulation.cs
@@ -41,7 +41,7 @@ namespace DVCustomCarLoader.LocoComponents.Steam
         {
             train.LogicCarInitialized -= OnLogicCarInitialized;
             CarDamageModel component = GetComponent<CarDamageModel>();
-            if (!train.playerSpawnedCar)
+            if (!train.playerSpawnedCar || Main.Settings.FeesForCCLLocos)
             {
                 tenderDebt = new CustomTenderDebtTracker(this, component, train.ID, train.carType);
                 SingletonBehaviour<LocoDebtController>.Instance.RegisterLocoDebtTracker(tenderDebt);
@@ -53,7 +53,7 @@ namespace DVCustomCarLoader.LocoComponents.Steam
         private void OnLocoDestroyed(TrainCar _)
         {
             train.OnDestroyCar -= OnLocoDestroyed;
-            if (!train.playerSpawnedCar)
+            if ((!train.playerSpawnedCar || Main.Settings.FeesForCCLLocos) && (tenderDebt != null))
             {
                 SingletonBehaviour<LocoDebtController>.Instance.StageLocoDebtOnLocoDestroy(tenderDebt);
             }

--- a/DVCustomCarLoader/LocoSpawnerInjector.cs
+++ b/DVCustomCarLoader/LocoSpawnerInjector.cs
@@ -1,0 +1,66 @@
+﻿using CCL_GameScripts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DVCustomCarLoader
+{
+    public static class LocoSpawnerInjector
+    {
+
+        public static void InjectCarsToSpawners()
+        {
+            foreach (var customCar in CustomCarManager.CustomCarTypes)
+            {
+                if (customCar.LocoSpawnLocations != StationYard.None)
+                {
+                    var typeList = new List<TrainCarType>() { customCar.CarType };
+                    var typeListWrapper = new ListTrainCarTypeWrapper(typeList);
+
+                    float consistLength = customCar.InterCouplerDistance + YardTracksOrganizer.Instance.GetSeparationLengthBetweenCars(1);
+
+                    if (!string.IsNullOrEmpty(customCar.TenderID))
+                    {
+                        if (CarTypeInjector.TryGetCustomCarById(customCar.TenderID, out var tender))
+                        {
+                            typeList.Add(tender.CarType);
+                            consistLength += tender.InterCouplerDistance + YardTracksOrganizer.Instance.GetSeparationLengthBetweenCars(1);
+                        }
+                        else
+                        {
+                            Main.Warning($"Couldn't find tender \"{customCar.TenderID}\" for loco {customCar.identifier}");
+                        }
+                    }
+
+                    foreach (string yardId in customCar.LocoSpawnLocations.YardIds())
+                    {
+                        if (!LogicController.Instance.YardIdToStationController.TryGetValue(yardId, out var controller))
+                        {
+                            Main.Error($"Invalid station {yardId} for loco {customCar.identifier} spawning");
+                            continue;
+                        }
+
+                        var spawners = controller.GetComponentsInChildren<StationLocoSpawner>();
+                        if (spawners.Length == 0)
+                        {
+                            Main.Warning($"Station {yardId} has no loco spawn tracks - can't spawn {customCar.identifier} here");
+                            continue;
+                        }
+
+                        foreach (var spawner in spawners)
+                        {
+                            double availableSpace = spawner.locoSpawnTrack.logicTrack.length;
+                            if (availableSpace >= consistLength)
+                            {
+                                Main.LogVerbose($"Added loco {customCar.identifier} to autospawn at {yardId}, track {spawner.locoSpawnTrackName}");
+                                spawner.locoTypeGroupsToSpawn.Add(typeListWrapper);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DVCustomCarLoader/Main.cs
+++ b/DVCustomCarLoader/Main.cs
@@ -84,6 +84,18 @@ namespace DVCustomCarLoader
         #endregion
     }
 
+	[HarmonyPatch(typeof(LogicController), "Start")]
+	public static class LogicController_Start_Patch
+    {
+		public static void Postfix(ref System.Collections.IEnumerator __result)
+		{
+			var wrapped = new WrappedEnumerator(__result);
+			wrapped.OnComplete += CustomCargoInjector.OnLogicControllerInitialized;
+			wrapped.OnComplete += LocoSpawnerInjector.InjectCarsToSpawners;
+			__result = wrapped;
+		}
+	}
+
     internal static class AppQuitWatcher
     {
 		public static bool isQuitting { get; private set; } = false;

--- a/DVCustomCarLoader/TrainCar_Patches.cs
+++ b/DVCustomCarLoader/TrainCar_Patches.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using DV.ServicePenalty;
 using DVCustomCarLoader.LocoComponents;
 using HarmonyLib;
 using UnityEngine;
@@ -37,6 +33,98 @@ namespace DVCustomCarLoader
             if (eventMgr)
             {
                 eventMgr.OnInteriorUnloaded();
+            }
+        }
+    }
+
+    [HarmonyPatch]
+    public static class LocoController_Debt_Patches
+    {
+        // On initialized
+        [HarmonyPatch(typeof(TrainCar), "InitializeLogicCarRelatedScript")]
+        [HarmonyPostfix]
+        public static void LogicCarRelatedScript(TrainCar __instance, ref CarDebtController ___carDebtController, CarStateSave ___carStateSave)
+        {
+            if (__instance.playerSpawnedCar && !__instance.IsLoco)
+            {
+                bool isCustomCar = CarTypeInjector.IsInCustomRange(__instance.carType);
+                if (Main.Settings.FeesForAllLocos || (isCustomCar && Main.Settings.FeesForCCLLocos))
+                {
+                    ___carDebtController.SetDebtTracker(__instance.CarDamage, __instance.CargoDamage);
+                    ___carStateSave.SetDebtTrackerCar(___carDebtController.CarDebtTracker);
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(LocoControllerDiesel), "OnLogicCarInitialized")]
+        [HarmonyPostfix]
+        public static void DieselInitialized(LocoControllerDiesel __instance, ref LocoDebtTrackerDiesel ___locoDebt,
+            DamageControllerDiesel ___damageController, DieselLocoSimulation ___sim)
+        {
+            if (__instance.train.playerSpawnedCar && Main.Settings.FeesForAllLocos)
+            {
+                ___locoDebt = new LocoDebtTrackerDiesel(___damageController, ___sim, __instance.train.ID, __instance.train.carType);
+                LocoDebtController.Instance.RegisterLocoDebtTracker(___locoDebt);
+            }
+        }
+
+        [HarmonyPatch(typeof(LocoControllerShunter), "OnLogicCarInitialized")]
+        [HarmonyPostfix]
+        public static void ShunterInitialized(LocoControllerShunter __instance, ref LocoDebtTrackerShunter ___locoDebt,
+            DamageControllerShunter ___damageController, ShunterLocoSimulation ___sim)
+        {
+            if (__instance.train.playerSpawnedCar && Main.Settings.FeesForAllLocos)
+            {
+                ___locoDebt = new LocoDebtTrackerShunter(___damageController, ___sim, __instance.train.ID, __instance.train.carType);
+                LocoDebtController.Instance.RegisterLocoDebtTracker(___locoDebt);
+            }
+        }
+
+        [HarmonyPatch(typeof(LocoControllerSteam), "OnLogicCarInitialized")]
+        [HarmonyPostfix]
+        public static void SteamInitialized(LocoControllerSteam __instance, ref LocoDebtTrackerSteam ___locoDebt,
+            DamageController ___damageController, SteamLocoSimulation ___sim)
+        {
+            if (__instance.train.playerSpawnedCar && Main.Settings.FeesForAllLocos)
+            {
+                ___locoDebt = new LocoDebtTrackerSteam(___damageController, ___sim, __instance.train.ID, __instance.train.carType);
+                LocoDebtController.Instance.RegisterLocoDebtTracker(___locoDebt);
+            }
+        }
+
+        [HarmonyPatch(typeof(TenderSimulation), "OnLogicCarInitialized")]
+        [HarmonyPostfix]
+        public static void TenderInitialized(TenderSimulation __instance, ref LocoDebtTrackerTender ___tenderDebt,
+            TrainCar ___train)
+        {
+            if (___train.playerSpawnedCar && Main.Settings.FeesForAllLocos)
+            {
+                var damageModel = __instance.GetComponent<CarDamageModel>();
+                ___tenderDebt = new LocoDebtTrackerTender(__instance, damageModel, ___train.ID, ___train.carType);
+                LocoDebtController.Instance.RegisterLocoDebtTracker(___tenderDebt);
+            }
+        }
+
+        // On destroyed
+        [HarmonyPatch(typeof(LocoControllerDiesel), "OnLocoDestroyed")]
+        [HarmonyPatch(typeof(LocoControllerShunter), "OnLocoDestroyed")]
+        [HarmonyPatch(typeof(LocoControllerSteam), "OnLocoDestroyed")]
+        [HarmonyPostfix]
+        public static void LocoDestroyed(TrainCar train, LocoDebtTrackerBase ___locoDebt)
+        {
+            if (train.playerSpawnedCar && Main.Settings.FeesForAllLocos && (___locoDebt != null))
+            {
+                LocoDebtController.Instance.StageLocoDebtOnLocoDestroy(___locoDebt);
+            }
+        }
+
+        [HarmonyPatch(typeof(TenderSimulation), "OnLocoDestroyed")]
+        [HarmonyPostfix]
+        public static void TenderDestroyed(TrainCar ___train, LocoDebtTrackerTender ___tenderDebt)
+        {
+            if (___train.playerSpawnedCar && Main.Settings.FeesForAllLocos && (___tenderDebt != null))
+            {
+                LocoDebtController.Instance.StageLocoDebtOnLocoDestroy(___tenderDebt);
             }
         }
     }


### PR DESCRIPTION
- Fix #43 steam engines not chuffing in reverse
- Fix #44 refrigerator based car types missing couplers
- Close #45 loco career management:
  - add options to train car setup for auto-spawning locos at stations
  - career manager tracking for CCL and default radio-spawned locomotives