### PR TITLE
Randomize loco selection of StationLocoSpawner

### DIFF
--- a/DVCustomCarLoader/LocoSpawnerInjector.cs
+++ b/DVCustomCarLoader/LocoSpawnerInjector.cs
@@ -9,7 +9,15 @@ namespace DVCustomCarLoader
 {
     public static class LocoSpawnerInjector
     {
-
+        [HarmonyPatch(typeof(StationLocoSpawner), nameof(StationLocoSpawner.Update))]
+        public static class UpdatePatch
+        {
+            public static void Postfix(StationLocoSpawner __instance)
+            {
+                __instance.nextLocoGroupSpawnIndex = UnityEngine.Random.Range(0, __instance.locoTypeGroupsToSpawn.Count);
+            }
+        }
+        
         public static void InjectCarsToSpawners()
         {
             foreach (var customCar in CustomCarManager.CustomCarTypes)


### PR DESCRIPTION
This is a quick and dirty fix to the problem that when you first enter a station during a play session you won't find ANY custom locomotive.

Better fix would be to randomize this selection of all `StationLocoSpawner` just once after all the custom loco spawns have been added to the List `locoTypeGroupsToSpawn` to reduce the performance overhead that comes from generating dozens of random numbers during every `Update` loop
