### PR TITLE
Improve readme and project infrastructure some

### DIFF
--- a/CCL_GameScripts/ArrayExtensionMethods.cs
+++ b/CCL_GameScripts/ArrayExtensionMethods.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace CCL_GameScripts
+{
+    internal static class ArrayExtensionMethods
+    {
+        internal static T[] Fill<T>(this T[] array, T item, int startIndex, int count)
+        {
+            int endIndex = Math.Min(startIndex + count, array.Length);
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                array[i] = item;
+            }
+            return array;
+        }
+
+        internal static T[] Fill<T>(this T[] array, T item)
+        {
+            return array.Fill(item, 0, array.Length);
+        }
+    }
+}

--- a/CCL_GameScripts/CCL_GameScripts.csproj
+++ b/CCL_GameScripts/CCL_GameScripts.csproj
@@ -110,4 +110,11 @@
     <Compile Include="TrainCarSetup.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>@echo off
+setlocal enableextensions
+md $(SolutionDir)\$(OutDir)
+endlocal
+xcopy /d /y $(TargetPath) $(SolutionDir)\$(OutDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/CCL_GameScripts/CCL_GameScripts.csproj
+++ b/CCL_GameScripts/CCL_GameScripts.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Effects\SmokeEmissionSetup.cs" />
     <Compile Include="Effects\SteamEmissionSetup.cs" />
     <Compile Include="Effects\WheelSparkSetup.cs" />
+    <Compile Include="ArrayExtensionMethods.cs" />
     <Compile Include="FireboxSetup.cs" />
     <Compile Include="JSONObject\JSONObject.cs" />
     <Compile Include="JSONObject\VectorTemplates.cs" />

--- a/CCL_GameScripts/CCL_GameScripts.csproj
+++ b/CCL_GameScripts/CCL_GameScripts.csproj
@@ -111,10 +111,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>@echo off
-setlocal enableextensions
-md $(SolutionDir)\$(OutDir)
+    <PostBuildEvent>setlocal enableextensions
+if not exist $(SolutionDir)$(OutDir) md $(SolutionDir)$(OutDir)
 endlocal
-xcopy /d /y $(TargetPath) $(SolutionDir)\$(OutDir)</PostBuildEvent>
+xcopy /d /y $(TargetPath) $(SolutionDir)$(OutDir)</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/CCL_GameScripts/Effects/DrivingAnimationSetup.cs
+++ b/CCL_GameScripts/Effects/DrivingAnimationSetup.cs
@@ -63,7 +63,7 @@ namespace CCL_GameScripts.Effects
 
                 if (UseDefaultRadiusForAll)
                 {
-                    Array.Fill(transformWheelRadii, DefaultWheelRadius);
+                    transformWheelRadii.Fill(DefaultWheelRadius);
                 }
             }
             else
@@ -94,7 +94,7 @@ namespace CCL_GameScripts.Effects
 
                 if (UseDefaultRadiusForAll)
                 {
-                    Array.Fill(animatorWheelRadii, DefaultWheelRadius);
+                    animatorWheelRadii.Fill(DefaultWheelRadius);
                 }
             }
             else

--- a/DVCustomCarLoader.sln
+++ b/DVCustomCarLoader.sln
@@ -7,6 +7,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DVCustomCarLoader", "DVCust
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CCL_GameScripts", "CCL_GameScripts\CCL_GameScripts.csproj", "{C191C5AC-990E-4CA6-9847-342B9CD92465}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EF124754-E21E-4CA9-BA2F-6BBBC521440E}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/DVCustomCarLoader/DVCustomCarLoader.csproj
+++ b/DVCustomCarLoader/DVCustomCarLoader.csproj
@@ -152,10 +152,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>@echo off
-setlocal enableextensions
-md $(SolutionDir)\$(OutDir)
+    <PostBuildEvent>setlocal enableextensions
+if not exist $(SolutionDir)$(OutDir) md $(SolutionDir)$(OutDir)
 endlocal
-xcopy /d /y $(TargetPath) $(SolutionDir)\$(OutDir)</PostBuildEvent>
+xcopy /d /y $(TargetPath) $(SolutionDir)$(OutDir)</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/DVCustomCarLoader/DVCustomCarLoader.csproj
+++ b/DVCustomCarLoader/DVCustomCarLoader.csproj
@@ -151,4 +151,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>@echo off
+setlocal enableextensions
+md $(SolutionDir)\$(OutDir)
+endlocal
+xcopy /d /y $(TargetPath) $(SolutionDir)\$(OutDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,47 @@
 # Custom Car Loader (CCL)
 
-Original project created by Freznosis is [here](https://github.com/Freznosis/DVCustomCarLoader)
+A mod for Derail Valley that allows the creation of custom rolling stock and locomotives. The mod is still under development, thus bugs and idiosyncrasies are to be expected. You can use the car creation package to setup a car in Unity and export it as an assetbundle, which can then be loaded into Derail Valley and spawned in-game. The cars can be spawned with the Comms Radio using the standard Car Spawner menu.
 
-A mod for Derail Valley that allows the creation of custom rolling stock & locomotives. The mod is still under development, thus bugs or idiosyncrasies are to be expected. You can use the car creation package to setup a car in Unity and export it as an assetbundle, which can then be loaded into Derail Valley and spawned in-game. The cars can be spawned with the Comms Radio using the standard Car Spawner menu.
+The [original project](https://github.com/Freznosis/DVCustomCarLoader) was created by Freznosis.
 
-## See the [Wiki](https://github.com/katycat5e/DVCustomCarLoader/wiki) for a guide to car creation
+## Car Creation
+
+Content authors can find a [guide to car creation](https://github.com/katycat5e/DVCustomCarLoader/wiki) in the Wiki.
+
+## Improving CCL
+
+Before opening pull requests, developers should build and test their changes locally to make sure everything is working as expected.
+
+### Environment Setup
+
+After cloning the repository, some setup is required in order to successfully build the mod DLLs. This guide assumes Visual Studio is used for development and the `DVCustomCarLoader` solution has already been opened.
+
+#### Reference Paths for CCL_GameScripts
+
+1. Right click the `CCL_GameScripts` project in the Solution Explorer window and choose `Properties` from the context menu
+1. Navigate to the `Reference Paths` tab of the properties window
+1. Click `Browse…` next to the `Folder:` input
+1. Navigate to `Derail Valley install directory > DerailValley_Data > Managed`
+1. Click `Select Folder` in the File Explorer dialog and then `Add Folder` below the `Folder:` input
+1. Click `Browse…` again
+1. Navigate to `Unity install directory > Editor > Data > Managed`
+1. Click `Select Folder` in the File Explorer dialog and then `Add Folder` below the `Folder:` input
+1. Save the CCL_GameScripts properties
+
+#### Reference Paths for DVCustomCarLoader
+
+1. Right click the `DVCustomCarLoader` project in the Solution Explorer window and choose `Properties` from the context menu
+1. Navigate to the `Reference Paths` tab of the properties window
+1. Click `Browse…` next to the `Folder:` input
+1. Navigate to `Derail Valley install directory > DerailValley_Data > Managed`
+1. Click `Select Folder` in the File Explorer dialog and then `Add Folder` below the `Folder:` input
+1. Click `Browse…` again
+1. Navigate to `Derail Valley install directory > DerailValley_Data > Managed > UnityModManager`
+1. Click `Select Folder` in the File Explorer dialog and then `Add Folder` below the `Folder:` input
+1. Save the DVCustomCarLoader properties
+
+> **Note:** The reference paths will be saved locally to `*.csproj.user` files. These files should not be committed as the reference paths may differ between each developer's environment. Git should already be set up to ignore these files.
+
+### Build Output
+
+The output DLLs will need to be copied into `Derail Valley install directory > Mods > DVCustomCarLoader` each time the solution is built. Copy them from `bin\Debug` or `bin\Release` depending on the selected build configuration.


### PR DESCRIPTION
Just attempting to make things easier for the next person who wants to help out.

I've document the local environment setup necessary to get the DLLs building as well as the development process of copying the DLLs into the Mods directory. In support of the latter point, I added some post-build events to make built DLLs easier to access. They basically just get copied into `bin\Debug` or `bin\Release` inside the root/solution directory.