### PR TITLE
Improve the Clear Folder dialog

### DIFF
--- a/CCL_GameScripts/Editor/ExportTrainCar.cs
+++ b/CCL_GameScripts/Editor/ExportTrainCar.cs
@@ -199,10 +199,10 @@ public class ExportTrainCar : EditorWindow
 		//Prompt to clear folder before exporting.
 		if (directory.GetFiles().Length > 0 || directory.GetDirectories().Length > 0)
 		{
-			if (EditorUtility.DisplayDialog("Clear Folder",
+			if (!EditorUtility.DisplayDialog("Clear Folder",
 				"The directory you selected isn't empty, would you like to clear the files from the folder before proceeding? \n \n WARNING: THIS WILL DELETE ALL FILES (BUT NOT DIRECTORIES) IN THE FOLDER.",
-				"Clear Folder",
-				"Cancel"))
+				"Skip",
+				"Clear Folder"))
 			{
 				//DANGEROUS METHOD, DONT USE WITHOUT CONFIDENCE
 				directory.Empty();


### PR DESCRIPTION
I've updated the wording of the negative response button so that it communicates that the export can and will proceed regardless of the option chosen. I've also reversed the logic so that the option that automatically receives focus when the dialog appears is the non-destructive option.