### PR TITLE
Add post build scripts to copy build outputs

### DIFF
--- a/CCL_GameScripts/CCL_GameScripts.csproj
+++ b/CCL_GameScripts/CCL_GameScripts.csproj
@@ -110,4 +110,10 @@
     <Compile Include="TrainCarSetup.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>setlocal enableextensions
+if not exist $(SolutionDir)$(OutDir) md $(SolutionDir)$(OutDir)
+endlocal
+xcopy /d /y $(TargetPath) $(SolutionDir)$(OutDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/DVCustomCarLoader/DVCustomCarLoader.csproj
+++ b/DVCustomCarLoader/DVCustomCarLoader.csproj
@@ -151,4 +151,10 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>setlocal enableextensions
+if not exist $(SolutionDir)$(OutDir) md $(SolutionDir)$(OutDir)
+endlocal
+xcopy /d /y $(TargetPath) $(SolutionDir)$(OutDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is a quality of life change for developers of CCL.

After building local changes to CCL, devs must copy the output `.dll` files to their Derail Valley mod directory in order to test their changes. Currently, that experience looks something like this:

1. Navigate to Repository Root > CCL_GameScripts > bin > Debug/Release
2. Find and copy `CCL_GameScripts.dll` (easy because it's at the top)
![image](https://user-images.githubusercontent.com/66900153/189310368-31f8a126-3773-4711-bcf9-86126dd967aa.png)
3. Navigate to Derail Valley Root > Mods > DVCustomCarLoader
4. Paste the file
5. Navigate to Repository Root > DVCustomCarLoader > bin > Debug/Release
6. Find and copy `DVCustomCarLoader.dll` (harder because it's amidst many `.dll` files, a number of which start with "DV")
![image](https://user-images.githubusercontent.com/66900153/189310942-9aa613bd-129b-4c1a-8f13-afb98cdbf655.png)
7. Navigate to Derail Valley Root > Mods > DVCustomCarLoader (again)
8. Paste the file

With these post-build scripts, the experience becomes:

1. Navigate to Repository Root > bin > Debug/Release
2. Copy `CCL_GameScripts.dll` and `DVCustomCarLoader.dll` (easy; the only two files in the directory)
![image](https://user-images.githubusercontent.com/66900153/189312297-ae7c99b6-cc7d-497b-a7b8-d317a1bff9e4.png)
3. Navigate to Derail Valley Root > Mods > DVCustomCarLoader
4. Paste the files

The post-build scripts reference paths inside the solution directory using macros, so they should port between different developers' VS environments seamlessly. They also don't directly install the `.dll` files into the active mod directory. Manual intervention is still required to copy the `.dll` files into the active mod directory, meaning devs retain full control of when this happens.