### PR TITLE
Fix NRE with reefer custom buffers

### DIFF
--- a/DVCustomCarLoader/CustomCar.cs
+++ b/DVCustomCarLoader/CustomCar.cs
@@ -78,6 +78,39 @@ namespace DVCustomCarLoader
             //==============================================================================================================
             #region Buffers/Chains
 
+            // copy main buffer part cohort
+            GameObject bufferRoot = basePrefab.transform.Find(CarPartNames.BUFFERS_ROOT).gameObject;
+            bufferRoot = Object.Instantiate(bufferRoot, newFab.transform);
+            bufferRoot.name = CarPartNames.BUFFERS_ROOT;
+
+            // special case for refrigerator - chain rigs are parented to car root instead of [buffers]
+            if (BaseCarType == TrainCarType.RefrigeratorWhite)
+            {
+                for (int i = 0; i < basePrefab.transform.childCount; i++)
+                {
+                    var child = basePrefab.transform.GetChild(i).gameObject;
+                    if (child.name == CarPartNames.BUFFER_CHAIN_REGULAR)
+                    {
+                        GameObject copiedChain = Object.Instantiate(child, bufferRoot.transform);
+                        copiedChain.name = CarPartNames.BUFFER_CHAIN_REGULAR;
+
+                        var bufferController = copiedChain.GetComponent<BufferController>();
+                        if (copiedChain.transform.localPosition.z > 0)
+                        {
+                            // front buffer
+                            bufferController.bufferModelLeft = bufferRoot.transform.Find(CarPartNames.BUFFER_PAD_FL);
+                            bufferController.bufferModelRight = bufferRoot.transform.Find(CarPartNames.BUFFER_PAD_FR);
+                        }
+                        else
+                        {
+                            // rear buffer
+                            bufferController.bufferModelLeft = bufferRoot.transform.Find(CarPartNames.BUFFER_PAD_RL);
+                            bufferController.bufferModelRight = bufferRoot.transform.Find(CarPartNames.BUFFER_PAD_RR);
+                        }
+                    }
+                }
+            }
+
             Vector3 frontRigPosition, rearRigPosition;
             if (carSetup.UseCustomBuffers)
             {
@@ -515,38 +548,8 @@ namespace DVCustomCarLoader
                 Main.Error("Missing rear coupler rig from prefab!");
             }
 
-            // copy main buffer part cohort
-            GameObject bufferRoot = basePrefab.transform.Find(CarPartNames.BUFFERS_ROOT).gameObject;
-            bufferRoot = Object.Instantiate(bufferRoot, newPrefab.transform);
-            bufferRoot.name = CarPartNames.BUFFERS_ROOT;
-
-            // special case for refrigerator - chain rigs are parented to car root instead of [buffers]
-            if (BaseCarType == TrainCarType.RefrigeratorWhite)
-            {
-                for (int i = 0; i < basePrefab.transform.childCount; i++)
-                {
-                    var child = basePrefab.transform.GetChild(i).gameObject;
-                    if (child.name == CarPartNames.BUFFER_CHAIN_REGULAR)
-                    {
-                        GameObject copiedChain = Object.Instantiate(child, bufferRoot.transform);
-                        copiedChain.name = CarPartNames.BUFFER_CHAIN_REGULAR;
-
-                        var bufferController = copiedChain.GetComponent<BufferController>();
-                        if (copiedChain.transform.localPosition.z > 0)
-                        {
-                            // front buffer
-                            bufferController.bufferModelLeft = bufferRoot.transform.Find(CarPartNames.BUFFER_PAD_FL);
-                            bufferController.bufferModelRight = bufferRoot.transform.Find(CarPartNames.BUFFER_PAD_FR);
-                        }
-                        else
-                        {
-                            // rear buffer
-                            bufferController.bufferModelLeft = bufferRoot.transform.Find(CarPartNames.BUFFER_PAD_RL);
-                            bufferController.bufferModelRight = bufferRoot.transform.Find(CarPartNames.BUFFER_PAD_RR);
-                        }
-                    }
-                }
-            }
+            // get copied buffer part cohort
+            GameObject bufferRoot = newPrefab.transform.Find(CarPartNames.BUFFERS_ROOT).gameObject;
 
             // adjust transforms of buffer components
             for (int i = 0; i < bufferRoot.transform.childCount; i++)
@@ -599,10 +602,8 @@ namespace DVCustomCarLoader
             Transform rearCouplerRig = newPrefab.transform.Find(CarPartNames.COUPLER_RIG_REAR);
             Vector3 rearRigPosition = rearCouplerRig.position;
 
-            // copy main buffer part cohort
-            GameObject bufferRoot = basePrefab.transform.Find(CarPartNames.BUFFERS_ROOT).gameObject;
-            bufferRoot = Object.Instantiate(bufferRoot, newPrefab.transform);
-            bufferRoot.name = CarPartNames.BUFFERS_ROOT;
+            // get copied buffer part cohort
+            GameObject bufferRoot = newPrefab.transform.Find(CarPartNames.BUFFERS_ROOT).gameObject;
 
             Transform newFrontBufferRig = null;
             Transform newRearBufferRig = null;


### PR DESCRIPTION
I started getting NREs after changing one of my custom car's `Base Car Type` to `Refrigerator White`:

> [DVCustomCarLoader] Reading directory: C:\Program Files (x86)\Steam\steamapps\common\Derail Valley\Mods\DVCustomCarLoader\Cars\CGW 18t Refrigerator
[DVCustomCarLoader] Reading JSON file: C:\Program Files (x86)\Steam\steamapps\common\Derail Valley\Mods\DVCustomCarLoader\Cars\CGW 18t Refrigerator\car.json
[DVCustomCarLoader] Loading AssetBundle: CGW_18t_Refrigerator_bundle at path C:\Program Files (x86)\Steam\steamapps\common\Derail Valley\Mods\DVCustomCarLoader\Cars\CGW 18t Refrigerator\CGW_18t_Refrigerator_bundle
[DVCustomCarLoader] Successfully loaded asset bundle. Bundle name is CGW_18t_Refrigerator_bundle
[DVCustomCarLoader] Successfully loaded prefab from asset bundle. Prefab name is exported_CGW_18t_Refrigerator
[DVCustomCarLoader] Augmenting prefab for CGW 18t Refrigerator
[DVCustomCarLoader] Destroy buffer pad Buffer_FL
[DVCustomCarLoader] Destroy buffer pad Buffer_FR
[DVCustomCarLoader] Destroy buffer pad Buffer_RL
[DVCustomCarLoader] Destroy buffer pad Buffer_RR
[DVCustomCarLoader] Adjust Hook Plate F
[DVCustomCarLoader] Adjust Hook Plate R
[DVCustomCarLoader] [Error] F1
[DVCustomCarLoader] [Error] F
[DVCustomCarLoader] [Error] System.NullReferenceException: Object reference not set to an instance of an object
  at DVCustomCarLoader.CustomCar.SetupCustomBuffers (UnityEngine.GameObject newPrefab, UnityEngine.GameObject basePrefab, System.Boolean customHoses) [0x00310] in <685df5fb9a5440a99f03a2feb95f707a>:0 
  at DVCustomCarLoader.CustomCar.FinalizePrefab () [0x000b2] in <685df5fb9a5440a99f03a2feb95f707a>:0 
  at DVCustomCarLoader.CustomCarManager.CreateCustomCar (System.String directory, JSONObject jsonFile) [0x00158] in <685df5fb9a5440a99f03a2feb95f707a>:0 
[DVCustomCarLoader] [Error] Failed to load custom car from C:\Program Files (x86)\Steam\steamapps\common\Derail Valley\Mods\DVCustomCarLoader\Cars\CGW 18t Refrigerator

I found the [two](https://github.com/katycat5e/DVCustomCarLoader/commit/153a6d1d432e935163f9fda19f9b8781acf7096d) [commits](https://github.com/katycat5e/DVCustomCarLoader/commit/2df3dc6e8c078bf24f1438c66a08d65a1aff83f5) related to #43, which fixed this problem for custom cars that use copied buffers. However, the problem was still occurring for custom cars using custom buffers because the code to copy the chain rigs was only applied to the `SetupDefaultBuffers` method. Moving the chain rig copying code out of the buffer setup method means that it now applies to both cases without duplication of code. After this change, the observed NRE has been resolved:

> [DVCustomCarLoader] Reading directory: C:\Program Files (x86)\Steam\steamapps\common\Derail Valley\Mods\DVCustomCarLoader\Cars\CGW 18t Refrigerator
[DVCustomCarLoader] Reading JSON file: C:\Program Files (x86)\Steam\steamapps\common\Derail Valley\Mods\DVCustomCarLoader\Cars\CGW 18t Refrigerator\car.json
[DVCustomCarLoader] Loading AssetBundle: CGW_18t_Refrigerator_bundle at path C:\Program Files (x86)\Steam\steamapps\common\Derail Valley\Mods\DVCustomCarLoader\Cars\CGW 18t Refrigerator\CGW_18t_Refrigerator_bundle
[DVCustomCarLoader] Successfully loaded asset bundle. Bundle name is CGW_18t_Refrigerator_bundle
[DVCustomCarLoader] Successfully loaded prefab from asset bundle. Prefab name is exported_CGW_18t_Refrigerator
[DVCustomCarLoader] Augmenting prefab for CGW 18t Refrigerator
[DVCustomCarLoader] Destroy buffer pad Buffer_FL
[DVCustomCarLoader] Destroy buffer pad Buffer_FR
[DVCustomCarLoader] Destroy buffer pad Buffer_RL
[DVCustomCarLoader] Destroy buffer pad Buffer_RR
[DVCustomCarLoader] Adjust Hook Plate F
[DVCustomCarLoader] Adjust Hook Plate R
[DVCustomCarLoader] Set newFrontBufferRig BuffersAndChainRig
[DVCustomCarLoader] Set newRearBufferRig BuffersAndChainRig
[DVCustomCarLoader] Adjust pads for BuffersAndChainRig, rig = True: [coupler_rig_front]
[DVCustomCarLoader] Adjust anchors for BuffersAndChainRig - BuffersAndChainRig
[DVCustomCarLoader] Adjust hoses for BuffersAndChainRig
[DVCustomCarLoader] Air hose = True
[DVCustomCarLoader] MU hose = False
[DVCustomCarLoader] Adjust pads for BuffersAndChainRig, rig = True: [coupler_rig_rear]
[DVCustomCarLoader] Adjust anchors for BuffersAndChainRig - BuffersAndChainRig
[DVCustomCarLoader] Adjust hoses for BuffersAndChainRig
[DVCustomCarLoader] Air hose = True
[DVCustomCarLoader] MU hose = False
[DVCustomCarLoader] Reusing walkable colliders as item colliders
[DVCustomCarLoader] Cargo models - [Medicine, none],[MeatProducts, none],[DairyProducts, none]
[DVCustomCarLoader] Cargo class: 9999, Damage price: 10000, ReplaceBase: False
[DVCustomCarLoader] Finalized prefab for CGW 18t Refrigerator
[DVCustomCarLoader] Cargo Medicine - CGW 18t Refrigerator - none
[DVCustomCarLoader] Cargo Meat Products - CGW 18t Refrigerator - none
[DVCustomCarLoader] Cargo Dairy Products - CGW 18t Refrigerator - none
[DVCustomCarLoader] Successfully added new car to spawn list: CGW 18t Refrigerator