### PR TITLE
Allow authors to define the intended bogie gauge

### DIFF
--- a/CCL_GameScripts/BogieSetup.cs
+++ b/CCL_GameScripts/BogieSetup.cs
@@ -15,9 +15,6 @@ namespace CCL_GameScripts
         [Range(0, 10)]
         public float AxleSeparation = 1.5f;
 
-        [Tooltip("The gauge of the bogies in millimeters. Used by the Gauge mod.")]
-        public float Gauge = 1435f;
-
         [Header("Physics")]
         [Range(0, 100000)]
         public float BrakingForcePerBar = 10000f;
@@ -28,7 +25,6 @@ namespace CCL_GameScripts
         public JSONObject GetJSON()
         {
             var repr = new JSONObject();
-            repr.AddField("gauge", Gauge);
             repr.AddField("axleCount", AxleCount);
             repr.AddField("axleSeparation", AxleSeparation);
             repr.AddField("brakingForcePerBar", BrakingForcePerBar);

--- a/CCL_GameScripts/BogieSetup.cs
+++ b/CCL_GameScripts/BogieSetup.cs
@@ -15,6 +15,9 @@ namespace CCL_GameScripts
         [Range(0, 10)]
         public float AxleSeparation = 1.5f;
 
+        [Tooltip("The gauge of the bogies in millimeters. Used by the Gauge mod.")]
+        public float Gauge = 1435f;
+
         [Header("Physics")]
         [Range(0, 100000)]
         public float BrakingForcePerBar = 10000f;
@@ -25,6 +28,7 @@ namespace CCL_GameScripts
         public JSONObject GetJSON()
         {
             var repr = new JSONObject();
+            repr.AddField("gauge", Gauge);
             repr.AddField("axleCount", AxleCount);
             repr.AddField("axleSeparation", AxleSeparation);
             repr.AddField("brakingForcePerBar", BrakingForcePerBar);

--- a/CCL_GameScripts/TrainCarSetup.cs
+++ b/CCL_GameScripts/TrainCarSetup.cs
@@ -64,6 +64,8 @@ namespace CCL_GameScripts
         public float FullDamagePrice = 10000f;
 
         [Header("Bogie Replacement")]
+        [Tooltip("The gauge of the bogies in millimeters. Used by the Gauge mod.")]
+        public float Gauge = 1435f;
         public bool UseCustomFrontBogie;
         public bool UseCustomRearBogie;
 

--- a/DVCustomCarLoader/CustomCar.cs
+++ b/DVCustomCarLoader/CustomCar.cs
@@ -865,6 +865,7 @@ namespace DVCustomCarLoader
     {
         public int AxleCount;
         public float AxleSeparation;
+        public float Gauge; // Used by the Gauge mod
         public float BrakingForcePerBar;
         public float RollingResistanceCoefficient;
 
@@ -874,6 +875,7 @@ namespace DVCustomCarLoader
             {
                 AxleCount = (int)json.GetField("axleCount").i,
                 AxleSeparation = json.GetField("axleSeparation").n,
+                Gauge = json.GetField("gauge").n,
                 BrakingForcePerBar = json.GetField("brakingForcePerBar").n,
                 RollingResistanceCoefficient = json.GetField("rollingResistance").n
             };

--- a/DVCustomCarLoader/CustomCar.cs
+++ b/DVCustomCarLoader/CustomCar.cs
@@ -40,6 +40,7 @@ namespace DVCustomCarLoader
         public string TenderID { get; protected set; }
 
         //Bogies
+        public float Gauge; // Used by the Gauge mod.
         public CustomBogieParams FrontBogieConfig = null;
         public CustomBogieParams RearBogieConfig = null;
         
@@ -347,6 +348,8 @@ namespace DVCustomCarLoader
 
             CargoClass = (CargoContainerType)carSetup.CargoClass;
             CargoCapacity = carSetup.CargoCapacity;
+
+            Gauge = carSetup.Gauge;
 
             var cargoSetups = newFab.GetComponentsInChildren<CargoModelSetup>(true);
             if (cargoSetups.Length > 0)
@@ -865,7 +868,6 @@ namespace DVCustomCarLoader
     {
         public int AxleCount;
         public float AxleSeparation;
-        public float Gauge; // Used by the Gauge mod
         public float BrakingForcePerBar;
         public float RollingResistanceCoefficient;
 
@@ -875,7 +877,6 @@ namespace DVCustomCarLoader
             {
                 AxleCount = (int)json.GetField("axleCount").i,
                 AxleSeparation = json.GetField("axleSeparation").n,
-                Gauge = json.GetField("gauge").n,
                 BrakingForcePerBar = json.GetField("brakingForcePerBar").n,
                 RollingResistanceCoefficient = json.GetField("rollingResistance").n
             };


### PR DESCRIPTION
Adds an option to the Bogie Setup script that allows authors to define the intended gauge of the bogie. This will be used by my upcoming Gauge mod to properly adjust them.

~~I'm leaving this as a draft until closer to the Guage mod's release which should be soon.~~
If you'd like this done in a different way, please let me know!