### PR TITLE
Add validation for custom bogie meshes

### DIFF
--- a/CCL_GameScripts/Editor/TrainCarValidator.cs
+++ b/CCL_GameScripts/Editor/TrainCarValidator.cs
@@ -299,6 +299,17 @@ namespace CCL_GameScripts
                     {
                         yield return Result.Failed($"Missing {CarPartNames.BOGIE_CAR} child for custom front bogie");
                     }
+                    foreach (MeshFilter filter in bogieCar.GetComponentsInChildren<MeshFilter>(true))
+                    {
+                        if (filter.sharedMesh == null)
+                        {
+                            yield return Result.Warning($"{filter.name} is missing a mesh");
+                        } 
+                        else if (!filter.sharedMesh.isReadable)
+                        {
+                            yield return Result.Warning($"Mesh {filter.sharedMesh.name} on {filter.name} doesn't have Read/Write enabled");
+                        }
+                    }
                 }
             }
 
@@ -320,6 +331,17 @@ namespace CCL_GameScripts
                     if (!bogieCar)
                     {
                         yield return Result.Failed($"Missing {CarPartNames.BOGIE_CAR} child for custom rear bogie");
+                    }
+                    foreach (MeshFilter filter in bogieCar.GetComponentsInChildren<MeshFilter>(true))
+                    {
+                        if (filter.sharedMesh == null)
+                        {
+                            yield return Result.Warning($"{filter.name} is missing a mesh");
+                        } 
+                        else if (!filter.sharedMesh.isReadable)
+                        {
+                            yield return Result.Warning($"Mesh {filter.sharedMesh.name} on {filter.name} doesn't have Read/Write enabled");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Adds validation for custom bogies meshes that checks two things. 
- There is a mesh present in all MeshFilters.
- Those meshes have Read/Write enabled. 

Read/Write is required to be enabled for the Gauge mod to resize the bogies. [More information on this setting](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Mesh-isReadable.html).

Both of these are currently warnings, but perhaps a missing mesh should fail?